### PR TITLE
increase z-index of modal menu

### DIFF
--- a/src/components/header.astro
+++ b/src/components/header.astro
@@ -11,7 +11,7 @@ const navItems = [
 
 <header
   id="page-header"
-  class="absolute bottom-0 z-10 flex items-center justify-between w-full px-8 py-4 text-white border-b border-transparent"
+  class="absolute bottom-0 z-20 flex items-center justify-between w-full px-8 py-4 text-white border-b border-transparent"
 >
   <a class="flex items-center gap-3 hover:!text-default" href="#">
     <h1 class="sr-only">Astro</h1>


### PR DESCRIPTION
Because the `GithubCorner` also has `z-10`, this prevents the user from closing the menu, because the close button is overlayed by the `GithubCorner`.